### PR TITLE
[Test] EntityViewComponent containing a custom struct with a string field inside it

### DIFF
--- a/Svelto.ECS.Tests/ECS/EntityCollectionTests.cs
+++ b/Svelto.ECS.Tests/ECS/EntityCollectionTests.cs
@@ -49,6 +49,9 @@ namespace Svelto.ECS.Tests.ECS
                 {
                     _entityFactory.BuildEntity<TestEntityWithComponentViewAndComponentStruct>(
                         new EGID(id++, _group + i), new object[] {new TestFloatValue(1f), new TestIntValue(1)});
+                    
+                    _entityFactory.BuildEntity<TestEntityViewComponentWithString>(
+                        new EGID(id++, _group + i), new object[] {new TestStringValue("test")});
                 }
             }
 
@@ -71,6 +74,15 @@ namespace Svelto.ECS.Tests.ECS
                 {
                     buffer[i].floatValue = 1 + buffer[i].ID.entityID;
                     buffer[i].intValue   = 1 + (int) buffer[i].ID.entityID;
+                }
+            }
+            
+            foreach (var ((buffer, count), exclusiveGroupStruct) in _testEngine
+                .entitiesDB.QueryEntities<TestEntityViewComponentString>())
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    buffer[i].TestStringValue.Value = (1 + buffer[i].ID.entityID).ToString();
                 }
             }
         }
@@ -173,6 +185,24 @@ namespace Svelto.ECS.Tests.ECS
                     var entity = Marshal.PtrToStructure<TestEntityStruct>(entitiesNativeArray + j * sizeOfStruct);
                     Assert.AreEqual(entities[j].ID.entityID + 1, entity.floatValue);
                     Assert.AreEqual(entities[j].ID.entityID + 1, entity.intValue);
+                }
+            }
+        }
+        
+        [TestCase(Description = "Test EntityCollection<T> String")]
+        public void TestEntityCollection1WithString()
+        {
+            for (uint i = 0; i < _groupCount; i++)
+            {
+                EntityCollection<TestEntityViewComponentString> entityViews =
+                    _testEngine.entitiesDB.QueryEntities<TestEntityViewComponentString>(_group + i);
+
+                var entityViewsBuffer = entityViews.ToBuffer();
+                var entityViewsManagedArray = entityViewsBuffer.buffer.ToManagedArray();
+
+                for (int j = 0; j < entityViews.count; j++)
+                {
+                    Assert.AreEqual((entityViews[j].ID.entityID + 1).ToString(), entityViewsManagedArray[j].TestStringValue.Value);
                 }
             }
         }

--- a/Svelto.ECS.Tests/ECS/EntityCollectionTests.cs
+++ b/Svelto.ECS.Tests/ECS/EntityCollectionTests.cs
@@ -52,6 +52,12 @@ namespace Svelto.ECS.Tests.ECS
                     
                     _entityFactory.BuildEntity<TestEntityViewComponentWithString>(
                         new EGID(id++, _group + i), new object[] {new TestStringValue("test")});
+                    
+                    _entityFactory.BuildEntity<TestEntityViewComponentWithCustomStruct>(
+                        new EGID(id++, _group + i), new object[]
+                        {
+                            new TestCustomStructWithString("test")
+                        });
                 }
             }
 
@@ -203,6 +209,25 @@ namespace Svelto.ECS.Tests.ECS
                 for (int j = 0; j < entityViews.count; j++)
                 {
                     Assert.AreEqual((entityViews[j].ID.entityID + 1).ToString(), entityViewsManagedArray[j].TestStringValue.Value);
+                }
+            }
+        }
+        
+        [TestCase(Description = "Test EntityCollection<T> CustomStruct String")]
+        public void TestEntityCollection1WithCustomStructString()
+        {
+            for (uint i = 0; i < _groupCount; i++)
+            {
+                EntityCollection<TestEntityViewComponentCustomStruct> entityViews =
+                    _testEngine.entitiesDB.QueryEntities<TestEntityViewComponentCustomStruct>(_group + i);
+
+                var entityViewsBuffer = entityViews.ToBuffer();
+                var entityViewsManagedArray = entityViewsBuffer.buffer.ToManagedArray();
+
+                for (int j = 0; j < entityViews.count; j++)
+                {
+                    Assert.AreEqual((entityViews[j].ID.entityID + 1).ToString(),
+                        entityViewsManagedArray[j].TestCustomStructString.Value);
                 }
             }
         }

--- a/Svelto.ECS.Tests/TestHelpers/TestEntityViewComponentWithString.cs
+++ b/Svelto.ECS.Tests/TestHelpers/TestEntityViewComponentWithString.cs
@@ -1,0 +1,4 @@
+namespace Svelto.ECS.Tests
+{
+    class TestEntityViewComponentWithString : GenericEntityDescriptor<TestEntityViewComponentString> { }
+}

--- a/Svelto.ECS.Tests/TestHelpers/TestEntityViewComponentWithString.cs
+++ b/Svelto.ECS.Tests/TestHelpers/TestEntityViewComponentWithString.cs
@@ -1,4 +1,5 @@
 namespace Svelto.ECS.Tests
 {
     class TestEntityViewComponentWithString : GenericEntityDescriptor<TestEntityViewComponentString> { }
+    class TestEntityViewComponentWithCustomStruct : GenericEntityDescriptor<TestEntityViewComponentCustomStruct> { }
 }

--- a/Svelto.ECS.Tests/TestHelpers/TestEntityViewStruct.cs
+++ b/Svelto.ECS.Tests/TestHelpers/TestEntityViewStruct.cs
@@ -56,4 +56,23 @@ namespace Svelto.ECS.Tests
         
         public EGID ID { get; set; }
     }
+
+    struct TestCustomStructWithString
+    {
+        public readonly string Value;
+        
+        public TestCustomStructWithString(string i)
+        {
+            Value = i;
+        }
+    }
+    
+    struct TestEntityViewComponentCustomStruct : IEntityViewComponent
+    {
+#pragma warning disable 649
+        public TestCustomStructWithString TestCustomStructString;
+#pragma warning restore 649
+        
+        public EGID ID { get; set; }
+    }
 }

--- a/Svelto.ECS.Tests/TestHelpers/TestEntityViewStruct.cs
+++ b/Svelto.ECS.Tests/TestHelpers/TestEntityViewStruct.cs
@@ -12,6 +12,11 @@ namespace Svelto.ECS.Tests
         int Value { get; set; }
     }
 
+    interface ITestStringValue
+    {
+        string Value { get; set; }
+    }
+
     class TestFloatValue : ITestFloatValue
     {
         public TestFloatValue(float i) { Value = i; }
@@ -26,6 +31,13 @@ namespace Svelto.ECS.Tests
         public int Value { get; set; }
     }
 
+    class TestStringValue : ITestStringValue
+    {
+        public TestStringValue(string i) { Value = i; }
+        
+        public string Value { get; set; }
+    }
+
     struct TestEntityViewStruct : IEntityViewComponent
     {
 #pragma warning disable 649
@@ -33,6 +45,15 @@ namespace Svelto.ECS.Tests
         public ITestIntValue   TestIntValue;
 #pragma warning restore 649
 
+        public EGID ID { get; set; }
+    }
+
+    struct TestEntityViewComponentString : IEntityViewComponent
+    {
+#pragma warning disable 649
+        public ITestStringValue TestStringValue;
+#pragma warning restore 649
+        
         public EGID ID { get; set; }
     }
 }


### PR DESCRIPTION
Added unit tests TestEntityCollection1WithString() and TestEntityCollection1WithCustomStructString()

The EntityViewComponent "TestEntityViewComponentCustomStruct" repros my issue with a custom struct with a string inside it.
The test is returning the exception
----> Svelto.ECS.ECSException : Entity View Components must hold only public interfaces, strings or unmanaged type fields. entity view: TestEntityViewComponentCustomStruct