### PR TITLE
Fix SveltoDictionary's Intersect and Exclude implementation

### DIFF
--- a/Svelto.ECS.Tests/Common/DataStructures/FasterDictionaryTests.cs
+++ b/Svelto.ECS.Tests/Common/DataStructures/FasterDictionaryTests.cs
@@ -17,5 +17,77 @@ namespace Svelto.Common.Tests.Datastructures
 
             Assert.Throws(typeof(SveltoDictionaryException), TestAddDup);
         }
+
+        [TestCase]
+        public void TestIntersect()
+        {
+            FasterDictionary<int, int> test1 = new FasterDictionary<int, int>();
+            FasterDictionary<int, int> test2 = new FasterDictionary<int, int>();
+
+            for (int i = 0; i < 100; ++i)
+                test1.Add(i, i);
+
+            for (int i = 0; i < 200; i += 2)
+                test2.Add(i, i);
+
+            test1.Intersect(test2);
+
+            for (int i = 0; i < test1.count; ++i)
+                Console.LogDebug(test1.unsafeKeys[i].key.ToString());
+
+            Assert.AreEqual(50, test1.count);
+
+            for (int i = 0; i < 100; i += 2)
+                Assert.IsTrue(test1.ContainsKey(i));
+        }
+
+        [TestCase]
+        public void TestExclude()
+        {
+            FasterDictionary<int, int> test1 = new FasterDictionary<int, int>();
+            FasterDictionary<int, int> test2 = new FasterDictionary<int, int>();
+
+            for (int i = 0; i < 100; ++i)
+                test1.Add(i, i);
+
+            for (int i = 0; i < 200; i += 2)
+                test2.Add(i, i);
+
+            test1.Intersect(test2);
+
+            for (int i = 0; i < test1.count; ++i)
+                Console.LogDebug(test1.unsafeKeys[i].key.ToString());
+
+            Assert.AreEqual(50, test1.count);
+
+            for (int i = 1; i < 100; i += 2)
+                Assert.IsTrue(test1.ContainsKey(i));
+        }
+
+        [TestCase]
+        public void TestUnion()
+        {
+            FasterDictionary<int, int> test1 = new FasterDictionary<int, int>();
+            FasterDictionary<int, int> test2 = new FasterDictionary<int, int>();
+
+            for (int i = 0; i < 100; ++i)
+                test1.Add(i, i);
+
+            for (int i = 0; i < 200; i += 2)
+                test2.Add(i, i);
+
+            test1.Union(test2);
+
+            for (int i = 0; i < test1.count; ++i)
+                Console.LogDebug(test1.unsafeKeys[i].key.ToString());
+
+            Assert.AreEqual(150, test1.count);
+
+            for (int i = 0; i < 100; i++)
+                Assert.IsTrue(test1.ContainsKey(i));
+
+            for (int i = 100; i < 200; i += 2)
+                Assert.IsTrue(test1.ContainsKey(i));
+        }
     }
 }

--- a/Svelto.ECS.Tests/Common/DataStructures/FasterDictionaryTests.cs
+++ b/Svelto.ECS.Tests/Common/DataStructures/FasterDictionaryTests.cs
@@ -32,9 +32,6 @@ namespace Svelto.Common.Tests.Datastructures
 
             test1.Intersect(test2);
 
-            for (int i = 0; i < test1.count; ++i)
-                Console.LogDebug(test1.unsafeKeys[i].key.ToString());
-
             Assert.AreEqual(50, test1.count);
 
             for (int i = 0; i < 100; i += 2)
@@ -53,10 +50,7 @@ namespace Svelto.Common.Tests.Datastructures
             for (int i = 0; i < 200; i += 2)
                 test2.Add(i, i);
 
-            test1.Intersect(test2);
-
-            for (int i = 0; i < test1.count; ++i)
-                Console.LogDebug(test1.unsafeKeys[i].key.ToString());
+            test1.Exclude(test2);
 
             Assert.AreEqual(50, test1.count);
 
@@ -77,9 +71,6 @@ namespace Svelto.Common.Tests.Datastructures
                 test2.Add(i, i);
 
             test1.Union(test2);
-
-            for (int i = 0; i < test1.count; ++i)
-                Console.LogDebug(test1.unsafeKeys[i].key.ToString());
 
             Assert.AreEqual(150, test1.count);
 

--- a/svelto/com.sebaslab.svelto.common/DataStructures/Dictionaries/SveltoDictionary.cs
+++ b/svelto/com.sebaslab.svelto.common/DataStructures/Dictionaries/SveltoDictionary.cs
@@ -661,7 +661,7 @@ namespace Svelto.DataStructures
             where OTValueStrategy : struct, IBufferStrategy<OTValue>
             where OTBucketStrategy : struct, IBufferStrategy<int>
         {
-            for (int i = 0; i < count; i++)
+            for (int i = count - 1; i >= 0; i--)
             {
                 var tKey = unsafeKeys[i].key;
                 if (otherDicKeys.ContainsKey(tKey) == false)
@@ -677,7 +677,7 @@ namespace Svelto.DataStructures
             where OTValueStrategy : struct, IBufferStrategy<OTValue>
             where OTBucketStrategy : struct, IBufferStrategy<int>
         {
-            for (int i = 0; i < count; i++)
+            for (int i = count - 1; i >= 0; i--)
             {
                 var tKey = unsafeKeys[i].key;
                 if (otherDicKeys.ContainsKey(tKey) == true)


### PR DESCRIPTION
Current implementation works wrong because the order of element changes while iterating, leads the evaluation skip for some elements.
It can be prevented with iterating backwards, when element removed the last element replace the place. Since last element always evaluated first when we iterate backwards, so there is no skipping.

* Added test case to test implementation.
* Modified SveltoDictionary to fix issue.