### PR TITLE
Implementor multithread fix test

### DIFF
--- a/svelto/com.sebaslab.svelto.ecs/Core/ComponentBuilder.cs
+++ b/svelto/com.sebaslab.svelto.ecs/Core/ComponentBuilder.cs
@@ -104,7 +104,7 @@ namespace Svelto.ECS
 
         public bool isUnmanaged => IS_UNMANAGED;
 
-        [ThreadStatic] static EntityViewComponentCache _localCache = new EntityViewComponentCache();
+        static ThreadLocal<EntityViewComponentCache> _localCache = new ThreadLocal<EntityViewComponentCache>(() => new EntityViewComponentCache());
 
         public void BuildEntityAndAddToList(ITypeSafeDictionary dictionary, EGID egid, IEnumerable<object> implementors)
         {
@@ -117,7 +117,7 @@ namespace Svelto.ECS
                 Check.Require(castedDic.ContainsKey(egid.entityID) == false,
                     $"building an entity with already used entity id! id: '{(ulong)egid}', {ENTITY_COMPONENT_NAME}");
 
-                this.SetEntityViewComponentImplementors(ref entityComponent, implementors, _localCache);
+                this.SetEntityViewComponentImplementors(ref entityComponent, implementors, _localCache.Value);
 
                 castedDic.Add(egid.entityID, entityComponent);
             }


### PR DESCRIPTION
NUnit doesn't like threads, so when the test cases were failing (throwing) in a different thread, simply running NUnit was insufficient.

I capture the exception with DispatchInfo inside the test function, so after the test (on the main thread) I can re-throw *with stack trace* if necessary

After fixing the test I changed the [ThreadStatic] annotation to ThreadLocal, because [ThreadStatic] specifies in the [docs ](https://docs.microsoft.com/en-us/dotnet/api/system.threadstaticattribute?view=net-6.0)that
> Do not specify initial values for fields marked with ThreadStaticAttribute, because such initialization occurs only once, when the class constructor executes, and therefore affects only one thread. 

Now all tests are passing