### PR TITLE
Revert "Add serialization&deserialization methods to ExclusiveGroupSt…

### DIFF
--- a/Svelto.ECS.Tests/ECS/SveltoSerialisationTests.cs
+++ b/Svelto.ECS.Tests/ECS/SveltoSerialisationTests.cs
@@ -287,15 +287,6 @@ namespace Svelto.ECS.Tests.Serialization
             newEnginesRoot.Dispose();
         }
 
-        [TestCase]
-        public void TestSerializingExclusiveGroupStruct()
-        {
-            ExclusiveGroupStruct egs = NamedGroup1.Group; 
-            Assert.That(
-                ExclusiveGroupStruct.Deserialize(egs.Serialize()) == egs
-            );
-        }
-
         EnginesRoot                       _enginesRoot;
         IEntityFactory                    _entityFactory;
         IEntityFunctions                  _entityFunctions;

--- a/svelto/com.sebaslab.svelto.ecs/Core/Groups/ExclusiveGroupStruct.cs
+++ b/svelto/com.sebaslab.svelto.ecs/Core/Groups/ExclusiveGroupStruct.cs
@@ -80,19 +80,7 @@ namespace Svelto.ECS
         public bool isInvalid => this == Invalid;
         public uint id        => _idInternal & 0xFFFFFF;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public uint ToIDAndBitmask() => _idInternal;
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint Serialize() => _idInternal;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ExclusiveGroupStruct Deserialize(uint serializedGroupId)
-        {
-            var egs = new ExclusiveGroupStruct(serializedGroupId);
-            DBC.ECS.Check.Ensure(egs.id < _globalId, "Invalid group ID deserialiased");
-            return egs;
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ExclusiveGroupStruct operator+(ExclusiveGroupStruct a, uint b)


### PR DESCRIPTION
This would have introduced dangerous code to the codebase. Using the 
```
uint GetHashFromGroup(ExclusiveGroupStruct groupStruct)
ExclusiveGroupStruct GetGroupFromHash(uint groupHash)
```
methods of GroupHashMap can be done by using the EntitySerializer as follows:
```
var ser = enginesRoot.GenerateEntitySerializer();
ser.GetHashFromGroup(someGroupStruct);
ser.GetGroupFromHash(42);
```

Simply put: with the above conversions `GetHashFromGroup` can be considered a `Serialize` and `GetGroupFromHash` a `Deserialize`

This reverts commit 14e3188cad0d57e4e43678d44bb6d16150bd151d.