### PR TITLE
Added EGID to EGID swapping check on react tests

### DIFF
--- a/Svelto.ECS.Tests/ECS/EnginesRoot.StructuralChangeCallbacksTests.cs
+++ b/Svelto.ECS.Tests/ECS/EnginesRoot.StructuralChangeCallbacksTests.cs
@@ -257,8 +257,14 @@ namespace Svelto.ECS.Tests.ECS
                 _functions.SwapEntityGroup<EntityDescriptorWithComponentAndViewComponent>
                     (new EGID(i, Groups.GroupA), Groups.GroupB);
             _scheduler.SubmitEntities();
+
+            // Swap specifically EGID to EGID with different Ids
+            for (uint i = 0; i < 100; i++)
+                _functions.SwapEntityGroup<EntityDescriptorWithComponentAndViewComponent>
+                    (new EGID(i, Groups.GroupB), new EGID(i + 200,Groups.GroupA));
+            _scheduler.SubmitEntities();
             
-            _functions.RemoveEntitiesFromGroup(Groups.GroupB);
+            _functions.RemoveEntitiesFromGroup(Groups.GroupA);
             _scheduler.SubmitEntities();
             
             Assert.That(megaReactEngine.legacyRemoveCounter, Is.EqualTo(total * 2));


### PR DESCRIPTION
This does throw an unexpected error, so the ECS project has to be updated.
This is for the bug that gives an error when you swap entities with different ids between groups and you have reactive engines listening.